### PR TITLE
Pass `params` when calling `_get_album`

### DIFF
--- a/GMusicProxy
+++ b/GMusicProxy
@@ -139,7 +139,7 @@ class GetHandler(BaseHTTPRequestHandler):
             elif p_type == 'song':
                 self._get_song(result)
             elif p_type == 'album':
-                self._get_album(result)
+                self._get_album(id=result, params=params)
             elif p_type == 'matches':
                 self._get_all_lambda(params, lambda: result, tuple_function=match_to_track)
         return True


### PR DESCRIPTION
The changes in 112aa65 added the argument `params` to the `_get_album`
function, but one of it's calling sites was not updated.