### PR TITLE
Implement OAuth2 and deprecate email/password

### DIFF
--- a/GMusicProxy
+++ b/GMusicProxy
@@ -573,7 +573,10 @@ class GetHandler(BaseHTTPRequestHandler):
                 logger.warning(
                     'Server denied authorization, trying to reconnect...')
                 api.logout()
-                api.login(config['email'], config['password'], config['device_id'])
+                if config['email'] is not None or config['password'] is not None:
+                    api.login(config['email'], config['password'], config['device_id'])
+                else:
+                    api.oauth_login(config['device_id'])
                 if api.is_authenticated():
                     self.handle_one_request()
                 else:
@@ -693,9 +696,9 @@ def getOptions(filename):
     parser.add_argument('-c', '--config', type=open,
                         help='specific configuration file to use')
     parser.add_argument(
-        '-e', '--email', help='email address of the Google account [required]')
+        '-e', '--email', help='[DEPRECATED] email address of the Google account')
     parser.add_argument(
-        '-p', '--password', help='password of the Google account (or an application-specific one if two-factor authentication is enabled) [required]')
+        '-p', '--password', help='[DEPRECATED] password of the Google account (or an application-specific one if two-factor authentication is enabled)')
     parser.add_argument(
         '-d', '--device-id', help='the ID of a registered Android/iOS device [default: fake-id based on mac address of network card]')
     parser.add_argument(
@@ -722,13 +725,13 @@ def getOptions(filename):
     parser.add_argument('-C', '--disable-playcount-increment', default=False, action='store_true',
                         help='disable the automatic increment of playcounts upon song fetch')
     parser.add_argument(
-        '--keyring-backend', help='name of the keyring backend to use instead of the default one')
+        '--keyring-backend', help='[DEPRECATED] name of the keyring backend to use instead of the default one')
     parser.add_argument('--list-keyring-backends', default=False,
-                        action='store_true', help='list the available keyring backends')
+                        action='store_true', help='[DEPRECATED] list the available keyring backends')
     parser.add_argument(
-        '--keyring-service', help='keyring service to use, takes precedence over --password if set')
+        '--keyring-service', help='[DEPRECATED] keyring service to use, takes precedence over --password if set')
     parser.add_argument(
-        '--keyring-entry', help='keyring entry to use, required if --keyring-service is used')
+        '--keyring-entry', help='[DEPRECATED] keyring entry to use, required if --keyring-service is used')
 
     gmp_config = ConfigParser()
     args = parser.parse_args()
@@ -781,17 +784,25 @@ def listDevices():
         sys.exit()
 
 
-def loginGM(email, password, device_id=gmusicapi.Mobileclient.FROM_MAC_ADDRESS):
+def loginGM(device_id=gmusicapi.Mobileclient.FROM_MAC_ADDRESS, email=None, password=None):
     requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
     api = gmusicapi.Mobileclient(debug_logging=config['debug'])
     if config['debug']:
         api.logger = logger
-    api.login(email, password, device_id)
-    if not api.is_authenticated():
-        logger.error('Sorry, those credentials weren\'t accepted.')
-        logger.error('Does your account have Two Factor Authentication (2FA) enabled?')
-        logger.error('If so, you must create and use an App Password in your account settings')
-        sys.exit(1)
+    if email is not None or password is not None:
+        api.login(email, password, device_id)
+        if not api.is_authenticated():
+            logger.error('Sorry, credentials weren\'t accepted.')
+            logger.error('Does your account have Two Factor Authentication (2FA) enabled?')
+            logger.error('If so, you must create and use an App Password in your account settings')
+            logger.error('Please consider switching to OAuth2 credentials.')
+            sys.exit(1)
+    else:
+        if not api.oauth_login(device_id):
+            api.perform_oauth(open_browser=True)
+            if not api.oauth_login(device_id):
+                logger.error('Failed to login with OAuth2 credentials.')
+                sys.exit(1)
     return api
 
 def autodetectLocalIP():
@@ -929,13 +940,12 @@ if __name__ == '__main__':
     if config['keyring_service'] is not None or config['keyring_entry'] is not None:
         config['password'] = getKeyringPassword()
 
-    if config['email'] is None or config['password'] is None or len(config['email']) == 0 or len(config['password']) == 0:
-        logger.error(
-            'Please, specify the credentials of your Google account in the config file or on the command-line.')
-        sys.exit(1)
+    if config['email'] is not None or config['password'] is not None:
+        logger.warning('Email and password based login is deprecated. Please switch to OAuth2. See README for more details.')
 
-    api = loginGM(config['email'], config['password'], gmusicapi.Mobileclient.FROM_MAC_ADDRESS if config[
-                  'device_id'] == '**auto**' else config['device_id'])
+    api = loginGM(gmusicapi.Mobileclient.FROM_MAC_ADDRESS if config[
+                  'device_id'] == '**auto**' else config['device_id'],
+                  email=config['email'], password=config['password'])
 
     with open("README.md", "r") as read_me:
         gmp_md = ''.join(read_me.readlines())

--- a/README.md
+++ b/README.md
@@ -189,15 +189,17 @@ python GMusicProxy
 ## Usage
 With the service running on a computer on the LAN, it can be used by any others of the same network.
 
-To launch the proxy you need the credentials of your Google account: *email* and *password*. If you are using the 2-factor authentication, you have to create an application-specific password to be used with this program. Another usefull information would be the device ID of an Android/iOS device registered in your account: you can discover it using the option `--list-devices` on the command-line. As default a fake-id, based on the mac address of the main network card of the server running the service, is used.
+To use the proxy, you first need to login via OAuth2. If you haven't authorized gmusicapi yet (or the credentials were revoked or deleted), when you first launch GMusicProxy, your browser will open letting you login and authorize gmusicapi. If no browser is available, the URL printed out can be used to login. After this, OAuth2 credentials (not your *email* and *password*) are cached to disk so future uses don't require you to login again.
+
+Another useful information would be the device ID of an Android/iOS device registered in your account: you can discover it using the option `--list-devices` on the command-line. As default a fake-id, based on the mac address of the main network card of the server running the service, is used.
 
 You can provide such necessary information, as well as other options, on the command-line of the program or using a configuration file.
 
 ### Command-line
 Here a list of the supported options on the command-line:
 
-- `--email`: email address of the Google account [required]
-- `--password`: password of the Google account [required]
+- `--email`: [DEPRECATED] email address of the Google account
+- `--password`: [DEPRECATED] password of the Google account
 - `--device-id`: the ID of a registered Android/iOS device [default: fake-id based on mac address of network card]
 - `--host`: host in the generated URLs [default: autodetected local ip address]
 - `--bind-address`: ip address to bind to [default: 0.0.0.0=all]
@@ -212,10 +214,10 @@ Here a list of the supported options on the command-line:
 - `--extended-m3u`: enable non-standard extended m3u headers
 - `--shoutcast-metadata`: enable Shoutcast metadata protocol support (disabling IDv3 tags)
 - `--disable-playcount-increment`: disable the automatic increment of playcounts upon song fetch
-- `--keyring-backend`: name of the keyring backend to use instead of the default one
-- `--list-keyring-backends`: list the available keyring backends
-- `--keyring-service`: keyring service to use, takes precedence over `--password` if set
-- `--keyring-entry`: keyring entry to use, required if `--keyring-service` is used
+- `--keyring-backend`: [DEPRECATED] name of the keyring backend to use instead of the default one
+- `--list-keyring-backends`: [DEPRECATED] list the available keyring backends
+- `--keyring-service`: [DEPRECATED] keyring service to use, takes precedence over `--password` if set
+- `--keyring-entry`: [DEPRECATED] keyring entry to use, required if `--keyring-service` is used
 
 ### Config file
 All the command-line options can be specified in a configuration file. An example of configuration with the strictly required options could look like this:


### PR DESCRIPTION
`gmusicapi` has deprecated email/password login and encourages use of
OAuth2 for authorization. As long as an email or password is not
specified in the configuration on the command-line, we attempt to
perform an oauth login. `gmusicapi` caches credentials to disk after a
successful authorization, so we use those if they exist, otherwise, we
prompt the user to login and authorize. This means that on a first run,
we open a browser (or just show a URL) to let the user login.

I am currently making use of this OAuth2 workflow, so I know that it
works for me. I don't know if you'd want to add some more information to
the README highlighting that fact that email/password is deprecated and
how to switch to oauth before merging.
